### PR TITLE
Add parquet content-type to response serialization

### DIFF
--- a/src/api/response.md
+++ b/src/api/response.md
@@ -15,3 +15,4 @@ ROAPI currently supports the following serialization formats:
 * `application/json`
 * `application/csv`
 * `application/vnd.apache.arrow.stream`
+* `application/parquet`


### PR DESCRIPTION
Documentation change for roapi/roapi#54 