### PR TITLE
Docs for lazy loading tables

### DIFF
--- a/src/config/blob-store.md
+++ b/src/config/blob-store.md
@@ -8,9 +8,12 @@ ROAPI currently supports the following blob storages:
 
 ## Filesystem
 
-Uri without a scheme prefix is treated as filesystem backed data source by
-ROAPI. For example, to serve a local parquet file `test_data/blogs.parquet`, you
-can just set the uri to the file path:
+Filesystem store can be specified using `file:` or `filesystem:` schemes.  In a
+Windows environment, the scheme is mandatory.  On Unix systems, a uri without a
+scheme prefix is treated as filesystem backed data source by ROAPI. 
+
+For example, to serve a local parquet file `test_data/blogs.parquet`, you can
+just set the uri to the file path:
 
 ```yaml
 tables:

--- a/src/config/blob-store.md
+++ b/src/config/blob-store.md
@@ -8,12 +8,9 @@ ROAPI currently supports the following blob storages:
 
 ## Filesystem
 
-Filesystem store can be specified using `file:` or `filesystem:` schemes.  In a
-Windows environment, the scheme is mandatory.  On Unix systems, a uri without a
-scheme prefix is treated as filesystem backed data source by ROAPI. 
-
-For example, to serve a local parquet file `test_data/blogs.parquet`, you can
-just set the uri to the file path:
+Uri without a scheme prefix is treated as filesystem backed data source by
+ROAPI. For example, to serve a local parquet file `test_data/blogs.parquet`, you
+can just set the uri to the file path:
 
 ```yaml
 tables:

--- a/src/config/dataset-formats/delta.md
+++ b/src/config/dataset-formats/delta.md
@@ -13,3 +13,30 @@ tables:
     option:
       format: "delta"
 ```
+
+## Large Datasets
+
+ROAPI loads the entire table into memory as the default behavior.  If your
+table is large or you want to avoid loading all data during startup, you can
+set an additional option `use_memory_table: false` (default: `true`). With that
+configuration, ROAPI will not copy the data into memory, but instructs datafusion
+to directly operate on the backing storage.
+
+At the moment, this comes with the following limitations:
+
+1. no nested schema: [datafusion#83](https://github.com/apache/arrow-datafusion/issues/83)
+2. missing support for cloud storage: [datafusion#616](https://github.com/apache/arrow-datafusion/issues/616)
+
+Example:
+
+```yaml
+tables:
+  - name: "mytable"
+    uri: "./path/to/delta_table"
+    option:
+      format: "delta"
+	  use_memory_table: false
+```
+
+Note that when providing `use_memory_table` option, it becomes necessary to
+also specify the format.

--- a/src/config/dataset-formats/delta.md
+++ b/src/config/dataset-formats/delta.md
@@ -13,30 +13,3 @@ tables:
     option:
       format: "delta"
 ```
-
-## Large Datasets
-
-ROAPI loads the entire table into memory as the default behavior.  If your
-table is large or you want to avoid loading all data during startup, you can
-set an additional option `use_memory_table: false` (default: `true`). With that
-configuration, ROAPI will not copy the data into memory, but instructs datafusion
-to directly operate on the backing storage.
-
-At the moment, this comes with the following limitations:
-
-1. no nested schema: [datafusion#83](https://github.com/apache/arrow-datafusion/issues/83)
-2. missing support for cloud storage: [datafusion#616](https://github.com/apache/arrow-datafusion/issues/616)
-
-Example:
-
-```yaml
-tables:
-  - name: "mytable"
-    uri: "./path/to/delta_table"
-    option:
-      format: "delta"
-	  use_memory_table: false
-```
-
-Note that when providing `use_memory_table` option, it becomes necessary to
-also specify the format.

--- a/src/config/dataset-formats/delta.md
+++ b/src/config/dataset-formats/delta.md
@@ -35,7 +35,7 @@ tables:
     uri: "./path/to/delta_table"
     option:
       format: "delta"
-	  use_memory_table: false
+      use_memory_table: false
 ```
 
 Note that when providing `use_memory_table` option, it becomes necessary to

--- a/src/config/dataset-formats/parquet.md
+++ b/src/config/dataset-formats/parquet.md
@@ -19,3 +19,30 @@ tables:
     option:
       format: "parquet"
 ```
+
+## Large Datasets
+
+ROAPI loads the entire table into memory as the default behavior.  If your
+table is large or you want to avoid loading all data during startup, you can
+set an additional option `use_memory_table: false` (default: `true`). With that
+configuration, ROAPI will not copy the data into memory, but instructs datafusion
+to directly operate on the backing storage.
+
+At the moment, this comes with the following limitations:
+
+1. no nested schema: [datafusion#83](https://github.com/apache/arrow-datafusion/issues/83)
+2. missing support for cloud storage: [datafusion#616](https://github.com/apache/arrow-datafusion/issues/616)
+
+Example:
+
+```yaml
+tables:
+  - name: "mytable"
+    uri: "./table_dir"
+    option:
+      format: "parquet"
+	  use_memory_table: false
+```
+
+Note that when providing `use_memory_table` option, it becomes necessary to
+also specify the format.

--- a/src/config/dataset-formats/parquet.md
+++ b/src/config/dataset-formats/parquet.md
@@ -41,7 +41,7 @@ tables:
     uri: "./table_dir"
     option:
       format: "parquet"
-	  use_memory_table: false
+      use_memory_table: false
 ```
 
 Note that when providing `use_memory_table` option, it becomes necessary to

--- a/src/config/dataset-formats/parquet.md
+++ b/src/config/dataset-formats/parquet.md
@@ -19,30 +19,3 @@ tables:
     option:
       format: "parquet"
 ```
-
-## Large Datasets
-
-ROAPI loads the entire table into memory as the default behavior.  If your
-table is large or you want to avoid loading all data during startup, you can
-set an additional option `use_memory_table: false` (default: `true`). With that
-configuration, ROAPI will not copy the data into memory, but instructs datafusion
-to directly operate on the backing storage.
-
-At the moment, this comes with the following limitations:
-
-1. no nested schema: [datafusion#83](https://github.com/apache/arrow-datafusion/issues/83)
-2. missing support for cloud storage: [datafusion#616](https://github.com/apache/arrow-datafusion/issues/616)
-
-Example:
-
-```yaml
-tables:
-  - name: "mytable"
-    uri: "./table_dir"
-    option:
-      format: "parquet"
-	  use_memory_table: false
-```
-
-Note that when providing `use_memory_table` option, it becomes necessary to
-also specify the format.


### PR DESCRIPTION
Describe additional config parameter, `use_memory_table` and its implications.

The paragraphs in parquet and delta sections are identical, which is a bit unfortunate but I didn't feel like overhauling the docs structure to maybe make room for a separate section, but I'm open to suggestions here.

Also added a piece about recently added `file://` schema / windows as I noticed that the docs didn't reflect that. As I wasn't involved in this one, I derived the documentation from the unit tests.
