### PR TITLE
minor typo fixes

### DIFF
--- a/src/config/dataset-formats/json.md
+++ b/src/config/dataset-formats/json.md
@@ -62,9 +62,9 @@ Can be stored as:
 ]
 ```
 
-When loading JSON rows using array encoding, one needs to explicily specify the
-schema since there is no column name in the datasource anymore for ROAPI to
-perform the schema inference:
+However, when loading JSON rows using array encoding, you must explicitly specify
+the schema, since there is no column name in the datasource anymore for ROAPI to
+perform the schema inference.
 
 ```yaml
 tables:

--- a/src/installation.md
+++ b/src/installation.md
@@ -2,10 +2,10 @@
 
 ## Pre-built binary
 
-Platform specific pre-built binaries for each release is hosted on our [Github
+Platform specific pre-built binaries for each release are hosted on our [Github
 release page](https://github.com/roapi/roapi/releases).
 
-You can download and install them with a signle command using pip:
+You can download and install them with a single command using pip:
 
 ```bash
 pip install roapi-http


### PR DESCRIPTION
Some minor typos fixed in the docs. I noticed these while playing with the docs.

Side note that it might be fun to have a GH Codespaces or Replit playground in the Quickstart section. Here's my initial Replit setup to that effect: https://replit.com/@whatrocks/MyROAPI.