### PR TITLE
github jobs is depreciated.. replaced w/ working link..

### DIFF
--- a/src/config/config-file.md
+++ b/src/config/config-file.md
@@ -40,7 +40,7 @@ tables:
       format: "json"
 
   - name: "github_jobs"
-    uri: "https://jobs.github.com/positions.json"
+    uri: "https://web.archive.org/web/20210507025928if_/https://jobs.github.com/positions.json"
 ```
 
 To run serve tables using config file:


### PR DESCRIPTION
internet archive, wayback machine link is used..