### PR TITLE
Default HTTP port in config example

### DIFF
--- a/src/config/config-file.md
+++ b/src/config/config-file.md
@@ -8,7 +8,7 @@ advanced format specific table options. For example:
 ```yaml
 addr:
   # binding address for TCP port that speaks HTTP protocol
-  http: 0.0.0.0:8084
+  http: 0.0.0.0:8080
   # binding address for TCP port that speaks Postgres wire protocol
   postgres: 0.0.0.0:5432
 tables:


### PR DESCRIPTION
Update the example HTTP port in the configuration sample to match other query/cli examples in the README file.

All examples used port `8080`, but we have `8084` in the configuration example. This is not a major issue, but if the ports are the same everywhere, it will be easier for new users to run the project and test the examples.
